### PR TITLE
Upgrade Cauldron schema from v0.0.0 to v1.0.0

### DIFF
--- a/cauldron.json
+++ b/cauldron.json
@@ -15,21 +15,6 @@
                 "container": "dbf29612d530e34a1e883ff7c70e3f1de87cb893",
                 "Staging": "15a92b4425fc0dabfd4444342d1a4e85737bf859"
               },
-              "nativeDeps": [
-                "ern-color-picker-api@0.0.1",
-                "react-native@0.51.0",
-                "react-native-electrode-bridge@1.5.9",
-                "react-native-ernmovie-api@0.0.9",
-                "react-native-ernnavigation-api@0.0.4",
-                "react-native-code-push@5.1.3-beta"
-              ],
-              "miniApps": {
-                "container": [
-                  "colorpickerminiapp@0.0.2",
-                  "movielistminiapp@0.0.9",
-                  "moviedetailsminiapp@0.0.8"
-                ]
-              },
               "codePush": {
                 "Staging": [
                   {
@@ -47,11 +32,28 @@
                       "colorpickerminiapp@0.0.3",
                       "movielistminiapp@0.0.9",
                       "moviedetailsminiapp@0.0.8"
-                    ]
+                    ],
+                    "jsApiImpls": []
                   }
                 ]
               },
-              "containerVersion": "1.0.1"
+              "containerVersion": "1.0.1",
+              "container": {
+                "nativeDeps": [
+                  "ern-color-picker-api@0.0.1",
+                  "react-native@0.51.0",
+                  "react-native-electrode-bridge@1.5.9",
+                  "react-native-ernmovie-api@0.0.9",
+                  "react-native-ernnavigation-api@0.0.4",
+                  "react-native-code-push@5.1.3-beta"
+                ],
+                "miniApps": [
+                  "colorpickerminiapp@0.0.2",
+                  "movielistminiapp@0.0.9",
+                  "moviedetailsminiapp@0.0.8"
+                ],
+                "jsApiImpls": []
+              }
             }
           ],
           "config": {
@@ -77,22 +79,23 @@
               "yarnLocks": {
                 "container": "4e54fa2728e08da074bbdfdff2206642f15eb092"
               },
-              "nativeDeps": [
-                "ern-color-picker-api@0.0.1",
-                "react-native@0.51.0",
-                "react-native-electrode-bridge@1.5.9",
-                "react-native-ernmovie-api@0.0.9",
-                "react-native-ernnavigation-api@0.0.4"
-              ],
-              "miniApps": {
-                "container": [
+              "codePush": {},
+              "containerVersion": "1.0.0",
+              "container": {
+                "nativeDeps": [
+                  "ern-color-picker-api@0.0.1",
+                  "react-native@0.51.0",
+                  "react-native-electrode-bridge@1.5.9",
+                  "react-native-ernmovie-api@0.0.9",
+                  "react-native-ernnavigation-api@0.0.4"
+                ],
+                "miniApps": [
                   "colorpickerminiapp@0.0.1",
                   "movielistminiapp@0.0.9",
                   "moviedetailsminiapp@0.0.8"
-                ]
-              },
-              "codePush": {},
-              "containerVersion": "1.0.0"
+                ],
+                "jsApiImpls": []
+              }
             }
           ],
           "config": {
@@ -109,5 +112,6 @@
         }
       ]
     }
-  ]
+  ],
+  "schemaVersion": "1.0.0"
 }


### PR DESCRIPTION
Upgrade Cauldron document for compatibility with Electrode Native 0.12.0+.